### PR TITLE
o365/client: add default app site, scope, domain

### DIFF
--- a/lib/microsoft/office/client.rb
+++ b/lib/microsoft/office/client.rb
@@ -40,10 +40,10 @@ class Microsoft::Officenew::Client
     def initialize(
             client_id:,
             client_secret:,
-            app_site:,
             app_token_url:,
-            app_scope:,
-            graph_domain:,
+            app_site: "https://login.microsoftonline.com",
+            app_scope: "https://graph.microsoft.com/.default",
+            graph_domain: "https://graph.microsoft.com",
             save_token: Proc.new{ |token| User.bucket.set("office-token", token) },
             get_token: Proc.new{ User.bucket.get("office-token", quiet: true) }
         )


### PR DESCRIPTION
# Description
Abstract very common default for three o365 graph api client parameters to the library level, such that they no longer need to be defined at the rails controller or engine driver level


## Type of change
- [x] add feature to library (non-breaking)

# Has this been tested?

Tested against a dev engine instance connected to a test o365 instance.